### PR TITLE
Fix abbr inconsistencies and corrupted titles in papers.bib

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -290,7 +290,7 @@
 }
 
 @inproceedings{shakeel_unify_asru2025,
-  abbr={ASR&Diarization},
+  abbr={ASR&SD},
   abbr_publisher={ASRU},
   title={Unifying Diarization, Separation, and ASR with Multi-Speaker Encoder},
   author={Muhammad Shakeel and Yui Sudo and Yifan Peng and Chyi-Jiunn Lin and Shinji Watanabe},
@@ -744,7 +744,7 @@
 }
 
 @inproceedings{bando_spatial_ssl_icassp2025,
-  abbr={SSL&ASR},
+  abbr={ASR&SSL},
   abbr_publisher={ICASSP},
   title={Investigation of Spatial Self-Supervised Learning and Its Application to Target Speaker Speech Recognition},
   author={Yoshiaki Bando and Samuele Cornell and Satoru Fukayama and Shinji Watanabe},
@@ -1234,7 +1234,7 @@ year={2024}
 }
 
 @inproceedings{cornell_icassp2024,
-    abbr={SD&ASR},
+    abbr={ASR&SD},
     abbr_publisher={ICASSP},
 author={Samuele Cornell and Jee-weon Jung and Shinji Watanabe and Stefano Squartini},
 title={One Model to Rule Them All? Towards End-to-End Joint Speaker Diarization and Speech Recognition},
@@ -1771,7 +1771,7 @@ year={2024}
 @inproceedings{Pend_is2023_2,
   abbr={ASR&ST},
   abbr_publisher={Interspeech},
-  title={lA Comparative Study on E-Branchformer vs Conformer in Speech Recognition, Translation, and Understanding Tasks},
+  title={A Comparative Study on E-Branchformer vs Conformer in Speech Recognition, Translation, and Understanding Tasks},
   author={Yifan Peng andKwangyoun Kim and Felix Wu and Brian Yan and Siddhant Arora and William Chen and Jiyang Tang and Suwon Shon and Prashant Sridhar and Shinji Watanabe},
   booktitle=interspeech,
   year={2023},
@@ -1952,7 +1952,7 @@ year={2024}
 @inproceedings{motoi_icassp2023,
   abbr={ST},
   abbr_publisher={ICASSP},
-  title={Align and Write and Re-order: Explainable End-to-End Speech Translation via Operation Sequence Generation},
+  title={Align, Write, Re-order: Explainable End-to-End Speech Translation via Operation Sequence Generation},
   author={Motoi Omachi and Brian Yan and Siddharth Dalmia and Yuya Fujita and and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
@@ -2058,7 +2058,7 @@ year={2024}
 }
 
 @inproceedings{zhe_icassp2023,
-  abbr={MultiModal},
+  abbr={Multimodal},
   abbr_publisher={ICASSP},
   title={The Multimodal Information Based Speech Processing (MISP) 2022 Challenge: Audio-Visual Diarization and Recognition},
   author={Zhe Wang and Shilong Wu and Hang Chen and Mao-Kui He and Jun Du and Chin-Hui Lee and Jingdong Chen and Shinji Watanabe and Sabato Siniscalchi and Odette Scharenborg and Diyuan Liu and Baocai Yin and Jia Pan and Jianqing Gao and and Cong Liu},
@@ -2067,7 +2067,7 @@ year={2024}
 }
 
 @inproceedings{junwei_icassp2023,
-  abbr={SSL&ASR},
+  abbr={ASR&SSL},
   abbr_publisher={ICASSP},
   title={FINDADAPTNET: Find and Insert Adapters by Learned Layer Importance},
   author={Junwei Huang and Karthik Ganesan and Soumi Maiti and Young Min Kim and Xuankai Chang and Paul Liang and and Shinji Watanabe},
@@ -2205,7 +2205,7 @@ year={2024}
 @inproceedings{yifan_slt2022,
   abbr={ASR&SLU},
   abbr_publisher={SLT},
-  title={A Study on the Integration of Pre-Trained SSL and ASR and LM and SLU Models for Spoken Language Understanding},
+  title={A Study on the Integration of Pre-Trained SSL, ASR, LM and SLU Models for Spoken Language Understanding},
   author={Yifan Peng and Siddhant Arora and Yosuke Higuchi and Yushi Ueda and Sujay Kumar and Karthik Ganesan and Siddharth Dalmia and Xuankai Chang and Shinji Watanabe},
   booktitle=SLT,
   year={2022},
@@ -2223,7 +2223,7 @@ year={2024}
 @inproceedings{yoshiki_slt2022,
   abbr={ASR&SE&SSL},
   abbr_publisher={SLT},
-  title={End-to-End Integration of Speech Recognition and Dereverberation and Beamforming and Self-Supervised Learning Representation},
+  title={End-to-End Integration of Speech Recognition, Dereverberation, Beamforming, and Self-Supervised Learning Representation},
   author={Yoshiki Masuyama and Xuankai Chang and Samuele Cornell and Shinji Watanabe and Nobutaka Ono},
   booktitle=SLT,
   year={2022},
@@ -2322,7 +2322,7 @@ year={2024}
 @inproceedings{yenju_interspeech2022,
   abbr={SE},
   abbr_publisher={Interspeech},
-  title={ESPnet-SE++: Speech Enhancement for Robust Speech Recognition and Translation and and Understanding},
+  title={ESPnet-SE++: Speech Enhancement for Robust Speech Recognition, Translation, and Understanding},
   author={Yen-Ju Lu and Xuankai Chang and Chenda Li and Wangyou Zhang and Samuele Cornell and Zhaoheng Ni and Yoshiki Masuyama and Brian Yan and Robin Scheibler and Zhong-Qiu Wang and Yu Tsao and Yanmin Qian and Shinji Watanabe},
   booktitle=interspeech,
   year={2022},
@@ -2718,7 +2718,7 @@ year={2024}
 
 
 @article{SHI2022101327,
-  abbr={SE+ASR},
+  abbr={SE&ASR},
   abbr_publisher={CSL},
   title = {An investigation of neural uncertainty estimation for target speaker extraction equipped RNN transducer},
   journal = {Computer Speech & Language},
@@ -2734,7 +2734,7 @@ year={2024}
 }
 
 @inproceedings{huang_asru2021,
-  abbr={ASR+TTS},
+  abbr={ASR&TTS},
   abbr_publisher={ASRU},
   title={On Prosody Modeling for ASR+TTS based Voice Conversion},
   author={Wen-Chin Huang and Tomoki Hayashi and Xinjian Li and Shinji Watanabe and Tomoki Toda},
@@ -2797,7 +2797,7 @@ year={2024}
 }
 
 @inproceedings{wu_asru2021,
-  abbr={ASR+TTS},
+  abbr={ASR&TTS},
   abbr_publisher={ASRU},
   title={Cross-lingual Transfer for Speech Processing using Acoustic Language Similarity},
   author={Peter Wu and Jiatong Shi and Yifan Zhong and Shinji Watanabe and Alan Black},
@@ -2937,7 +2937,7 @@ year={2024}
 }
 
 @inproceedings{meekaku2021ZeroSpeech,
-  abbr={ASR & SpeDialog},
+  abbr={SSL},
   abbr_publisher={Interspeech},
   title={Speech Representation Learning Combining Conformer CPC with Deep Cluster for the ZeroSpeech Challenge 2021},
   author={Maekaku, Takashi and Chang, Xuankai and Fujita, Yuya and Chen, Li-Wei and Watanabe, Shinji and Rudnicky, Alexander},
@@ -3056,7 +3056,7 @@ year={2024}
 }
 
 @inproceedings{raj2021integration,
-  abbr={SE&SE&ASR},
+  abbr={SS&SD&ASR},
   abbr_publisher={SLT},
   title={Integration of speech separation, diarization, and recognition for multi-speaker meetings: System description, comparison, and analysis},
   author={Raj, Desh and Denisov, Pavel and Chen, Zhuo and Erdogan, Hakan and Huang, Zili and He, Maokui and Watanabe, Shinji and Du, Jun and Yoshioka, Takuya and Luo, Yi and others},
@@ -3367,7 +3367,7 @@ year={2024}
 }
 
 @article{huh2020augmentation,
-  abbr={SR&SSL},
+  abbr={Speaker&SSL},
   abbr_publisher={NeurIPS},
   title={Augmentation adversarial training for self-supervised speaker recognition},
   author={Huh, Jaesung and Heo, Hee Soo and Kang, Jingu and Watanabe, Shinji and Chung, Joon Son},
@@ -3593,7 +3593,7 @@ year={2024}
 }
 
 @inproceedings{kanda2019simultaneous,
-  abbr={ASR+SD},
+  abbr={ASR&SD},
   abbr_publisher={ASRU},
   title={Simultaneous speech recognition and speaker diarization for monaural dialogue recordings with target-speaker acoustic models},
   author={Kanda, Naoyuki and Horiguchi, Shota and Fujita, Yusuke and Xue, Yawen and Nagamatsu, Kenji and Watanabe, Shinji},


### PR DESCRIPTION
Metadata cleanup in `_bibliography/papers.bib`. No new publications are added
here and no other files are touched — the diff is 17 insertions / 17 deletions,
all on `abbr` or `title` lines.

## `abbr` cleanup (12 entries)

Reduces 76 distinct `abbr` values to 69. The field had no controlled vocabulary,
so the same topic had accumulated several spellings — each of which renders as a
visibly different badge on the publications page.

| Was | Now | Why |
|---|---|---|
| `ASR+SD`, `SE+ASR`, `ASR+TTS` (x2) | `&` form | separator: every other multi-topic value uses `&` |
| `MultiModal` | `Multimodal` | matches the sibling MISP entry |
| `SE&SE&ASR` | `SS&SD&ASR` | duplicated component, and the paper is separation + diarization + recognition (SE is enhancement, not separation) |
| `ASR & SpeDialog` | `SSL` | wrong topic — the paper is ZeroSpeech representation learning, and `SpeDialog` appeared nowhere else in the file |
| `ASR&Diarization` | `ASR&SD` | `Diarization` used once, `SD` used 26 times |
| `SR&SSL` | `Speaker&SSL` | `SR` used once, `Speaker` used 5 times |
| `SSL&ASR` (x2), `SD&ASR` | `ASR&SSL`, `ASR&SD` | same components, two spellings |

## Title fixes (5 entries)

Each corrected title was checked against DBLP's record of the **published**
version, not against any single web page.

| Entry | Problem |
|---|---|
| `Pend_is2023_2` | stray leading `l` in `lA Comparative Study` |
| `yenju_interspeech2022` | doubled `and`: `Translation and and Understanding` |
| `motoi_icassp2023` | commas in the real title replaced by `and` |
| `yifan_slt2022` | same |
| `yoshiki_slt2022` | same |

These were found by diffing our titles against Shinji's publication list; the
comma-to-`and` pattern looks like a systematic import artefact rather than
separate typos.

## Verification

`bundle exec jekyll build` runs clean. In the built
`_site/publications/index.html`: every corrected title and badge renders, and
all nine old `abbr` values plus all five old title strings are gone (0
occurrences each).

Note: the build needs `LANG`/`LC_ALL` set to a UTF-8 locale, otherwise it fails
on `_posts/2018-12-31-paper-list.md` with `invalid byte sequence in US-ASCII`.
That is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)