### PR TITLE
Fix malformed author separators in papers.bib

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1708,7 +1708,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={Interspeech},
   title={Bayes Risk Transducer: Transducer with Controllable Alignment Prediction},
-  author={Jinchuan Tian and Jianwei Yu and Hangting Chen and Brian Yan and Chao Weng andDong Yu and Shinji Watanabe},
+  author={Jinchuan Tian and Jianwei Yu and Hangting Chen and Brian Yan and Chao Weng and Dong Yu and Shinji Watanabe},
   booktitle=interspeech,
   year={2023},
 }
@@ -1772,7 +1772,7 @@ year={2024}
   abbr={ASR&ST},
   abbr_publisher={Interspeech},
   title={A Comparative Study on E-Branchformer vs Conformer in Speech Recognition, Translation, and Understanding Tasks},
-  author={Yifan Peng andKwangyoun Kim and Felix Wu and Brian Yan and Siddhant Arora and William Chen and Jiyang Tang and Suwon Shon and Prashant Sridhar and Shinji Watanabe},
+  author={Yifan Peng and Kwangyoun Kim and Felix Wu and Brian Yan and Siddhant Arora and William Chen and Jiyang Tang and Suwon Shon and Prashant Sridhar and Shinji Watanabe},
   booktitle=interspeech,
   year={2023},
 }
@@ -1818,7 +1818,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={Multi-blank Transducers for Speech Recognition},
-  author={Hainan Xu and Fei Jia and Somshubra Majumdar and Shinji Watanabe and and Boris Ginsburg},
+  author={Hainan Xu and Fei Jia and Somshubra Majumdar and Shinji Watanabe and Boris Ginsburg},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1827,7 +1827,7 @@ year={2024}
   abbr={SE},
   abbr_publisher={ICASSP},
   title={PAAPLoss: A Phonetic-Aligned Acoustic Parameter Loss for Speech Enhancement},
-  author={Muqiao Yang and Joseph Konan and David Bick and Yunyang Zeng and Shuo Han and Anurag Kumar and Shinji Watanabe and and Bhiksha Raj},
+  author={Muqiao Yang and Joseph Konan and David Bick and Yunyang Zeng and Shuo Han and Anurag Kumar and Shinji Watanabe and Bhiksha Raj},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1836,7 +1836,7 @@ year={2024}
   abbr={SD},
   abbr_publisher={ICASSP},
   title={In search of strong embedding extractors for speaker diarisation},
-  author={Jee-weon Jung and Hee-Soo Heo and Bong-Jin Lee and Jaesung Huh and Andrew Brown and Youngki Kwon and Shinji Watanabe and and Joon Son Chung},
+  author={Jee-weon Jung and Hee-Soo Heo and Bong-Jin Lee and Jaesung Huh and Andrew Brown and Youngki Kwon and Shinji Watanabe and Joon Son Chung},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1845,7 +1845,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={Wav2Seq: Pre-training Speech-to-Text Encoder-Decoder Models Using Pseudo Languages},
-  author={Felix Wu and Kwangyoun Kim and Shinji Watanabe and Kyu J. Han and Ryan McDonald and Kilian Q. Weinberger and and Yoav Artzi},
+  author={Felix Wu and Kwangyoun Kim and Shinji Watanabe and Kyu J. Han and Ryan McDonald and Kilian Q. Weinberger and Yoav Artzi},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1854,7 +1854,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={BECTRA: Transducer-based End-to-End ASR with BERT-Enhanced Encoder},
-  author={Yosuke Higuchi and Tetsuji Ogawa and Tetsunori Kobayashi and and Shinji Watanabe},
+  author={Yosuke Higuchi and Tetsuji Ogawa and Tetsunori Kobayashi and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1863,7 +1863,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={InterMPL: Momentum Pseudo-Labeling with Intermediate CTC Loss},
-  author={Yosuke Higuchi and Tetsuji Ogawa and Tetsunori Kobayashi and and Shinji Watanabe},
+  author={Yosuke Higuchi and Tetsuji Ogawa and Tetsunori Kobayashi and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1872,7 +1872,7 @@ year={2024}
   abbr={TTS&SSL},
   abbr_publisher={ICASSP},
   title={A Unified One-Shot Prosody and Speaker Conversion System with Self-Supervised Discrete Speech Units},
-  author={Li-Wei Chen and Shinji Watanabe and and Alexander Rudnicky},
+  author={Li-Wei Chen and Shinji Watanabe and Alexander Rudnicky},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1881,7 +1881,7 @@ year={2024}
   abbr={SE},
   abbr_publisher={ICASSP},
   title={TAPLoss: A Temporal Acoustic Parameter Loss for Speech Enhancement},
-  author={Yunyang Zeng and Joseph Konan and Shuo Han and David Bick and Muqiao Yang and Anurag Kumar and Shinji Watanabe and and Bhiksha Raj},
+  author={Yunyang Zeng and Joseph Konan and Shuo Han and David Bick and Muqiao Yang and Anurag Kumar and Shinji Watanabe and Bhiksha Raj},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1890,7 +1890,7 @@ year={2024}
   abbr={SSL&SLU},
   abbr_publisher={ICASSP},
   title={Bridging Speech and Text Pre-trained Models with Unsupervised ASR},
-  author={Jiatong Shi and Chan-Jan Hsu and Holam Chung and Dongji Gao and Paola Garcia and Shinji Watanabe and Ann Lee and and Hung-yi Lee},
+  author={Jiatong Shi and Chan-Jan Hsu and Holam Chung and Dongji Gao and Paola Garcia and Shinji Watanabe and Ann Lee and Hung-yi Lee},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1899,7 +1899,7 @@ year={2024}
   abbr={Music},
   abbr_publisher={ICASSP},
   title={PHONEix: Acoustic Feature Processing Strategy for Enhanced Singing Pronunciation with Phoneme Distribution Predictor},
-  author={Yuning Wu and Jiatong Shi and Tao Qian and and Qin Jin},
+  author={Yuning Wu and Jiatong Shi and Tao Qian and Qin Jin},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1908,7 +1908,7 @@ year={2024}
   abbr={SLU},
   abbr_publisher={ICASSP},
   title={Speech summarization of long spoken document: Improving memory efficiency of speech/text encoders},
-  author={Takatomo Kano and Atsunori Ogawa and Marc Delcroix and Roshan Sharma and Kohei Matsuura and and Shinji Watanabe},
+  author={Takatomo Kano and Atsunori Ogawa and Marc Delcroix and Roshan Sharma and Kohei Matsuura and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1917,7 +1917,7 @@ year={2024}
   abbr={SSL},
   abbr_publisher={ICASSP},
   title={Context-Aware Fine-Tuning of Self-Supervised Speech Models},
-  author={Suwon Shon and Felix Wu and Kwangyoun Kim and Prashant Sridhar and Karen Livescu and and Shinji Watanabe},
+  author={Suwon Shon and Felix Wu and Kwangyoun Kim and Prashant Sridhar and Karen Livescu and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1926,7 +1926,7 @@ year={2024}
   abbr={S2ST},
   abbr_publisher={ICASSP},
   title={Enhancing Speech-To-Speech Translation with Multiple TTS Targets},
-  author={Jiatong Shi and Yun Tang and Ann Lee and Hirofumi Inaguma and Changhan Wang and Juan Pino and and Shinji Watanabe},
+  author={Jiatong Shi and Yun Tang and Ann Lee and Hirofumi Inaguma and Changhan Wang and Juan Pino and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1935,7 +1935,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={Streaming Joint Speech Recognition and Disfluency Detection},
-  author={Hayato Futami and Emiru Tsunoo and Kentaro Shibata and Yosuke Kashiwagi and Takao Okuda and Siddhant Arora and and Shinji Watanabe},
+  author={Hayato Futami and Emiru Tsunoo and Kentaro Shibata and Yosuke Kashiwagi and Takao Okuda and Siddhant Arora and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1944,7 +1944,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={Towards Zero-Shot Code-Switched Speech Recognition},
-  author={Brian Yan and Matthew Wiesner and Ondrej Klejch and Preethi Jyothi and and Shinji Watanabe},
+  author={Brian Yan and Matthew Wiesner and Ondrej Klejch and Preethi Jyothi and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1953,7 +1953,7 @@ year={2024}
   abbr={ST},
   abbr_publisher={ICASSP},
   title={Align, Write, Re-order: Explainable End-to-End Speech Translation via Operation Sequence Generation},
-  author={Motoi Omachi and Brian Yan and Siddharth Dalmia and Yuya Fujita and and Shinji Watanabe},
+  author={Motoi Omachi and Brian Yan and Siddharth Dalmia and Yuya Fujita and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1962,7 +1962,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={Improving Massively Multilingual ASR With Auxiliary CTC Objectives},
-  author={William Chen and Brian Yan and Jiatong Shi and Yifan Peng and Soumi Maiti and and Shinji Watanabe},
+  author={William Chen and Brian Yan and Jiatong Shi and Yifan Peng and Soumi Maiti and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1971,7 +1971,7 @@ year={2024}
   abbr={SSL},
   abbr_publisher={ICASSP},
   title={SpeechLMScore: Evaluating Speech Generation Using Speech Language Model},
-  author={Soumi Maiti and Yifan Peng and Takaaki Saeki and and Shinji Watanabe},
+  author={Soumi Maiti and Yifan Peng and Takaaki Saeki and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1980,7 +1980,7 @@ year={2024}
   abbr={TTS},
   abbr_publisher={ICASSP},
   title={Speaker-Independent Acoustic-to-Articulatory Speech Inversion},
-  author={Peter Wu and Li-Wei Chen and Cheol Jun Cho and Shinji Watanabe and Louis Goldstein and Alan W. Black and and Gopala K. Anumanchipalli},
+  author={Peter Wu and Li-Wei Chen and Cheol Jun Cho and Shinji Watanabe and Louis Goldstein and Alan W. Black and Gopala K. Anumanchipalli},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1989,7 +1989,7 @@ year={2024}
   abbr={SLU},
   abbr_publisher={ICASSP},
   title={Joint Modelling of Spoken Language Understanding Tasks with Integrated Dialog History},
-  author={Siddhant Arora and Hayato Futami and Emiru Tsunoo and Brian Yan and and Shinji Watanabe},
+  author={Siddhant Arora and Hayato Futami and Emiru Tsunoo and Brian Yan and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -1998,7 +1998,7 @@ year={2024}
   abbr={SS},
   abbr_publisher={ICASSP},
   title={TF-GridNet: Making Time-Frequency Domain Models Great Again for Monaural Speaker Separation},
-  author={Zhong-Qiu Wang and Samuele Cornell and Shukjae Choi and Younglo Lee and Byeong-Yeol Kim and and Shinji Watanabe},
+  author={Zhong-Qiu Wang and Samuele Cornell and Shukjae Choi and Younglo Lee and Byeong-Yeol Kim and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2007,7 +2007,7 @@ year={2024}
   abbr={ASR&SSL},
   abbr_publisher={ICASSP},
   title={EURO: ESPnet Unsupervised ASR Open-Source Toolkit},
-  author={Dongji Gao and Jiatong Shi and Shun-Po Chuang and Leibny Paola Garcia and Hung-yi Lee and Shinji Watanabe and and Sanjeev Khudanpur},
+  author={Dongji Gao and Jiatong Shi and Shun-Po Chuang and Leibny Paola Garcia and Hung-yi Lee and Shinji Watanabe and Sanjeev Khudanpur},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2016,7 +2016,7 @@ year={2024}
   abbr={SE},
   abbr_publisher={ICASSP},
   title={Neural Speech Enhancement with Very Low Algorithmic Latency and Complexity via Integrated Full- and Sub-Band Modeling},
-  author={Zhong-Qiu Wang and Samuele Cornell and Shukjae Choi and Younglo Lee and Byeong-Yeol Kim and and Shinji Watanabe},
+  author={Zhong-Qiu Wang and Samuele Cornell and Shukjae Choi and Younglo Lee and Byeong-Yeol Kim and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2025,7 +2025,7 @@ year={2024}
   abbr={ASR&SSL},
   abbr_publisher={ICASSP},
   title={Avoid Overthinking in Self-Supervised Models for Speech Recognition},
-  author={Dan Berrebbi and Brian Yan and and Shinji Watanabe},
+  author={Dan Berrebbi and Brian Yan and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2034,7 +2034,7 @@ year={2024}
   abbr={TTS},
   abbr_publisher={ICASSP},
   title={Articulatory Representation Learning Via Joint Factor Analysis and Neural Matrix Factorization},
-  author={Jiachen Lian and Alan W Black and Yijing Lu and Louis Goldstein and Shinji Watanabe and and Gopala K. Anumanchipalli},
+  author={Jiachen Lian and Alan W Black and Yijing Lu and Louis Goldstein and Shinji Watanabe and Gopala K. Anumanchipalli},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2043,7 +2043,7 @@ year={2024}
   abbr={ASR&SLU&SSL},
   abbr_publisher={ICASSP},
   title={Structured Pruning of Self-Supervised Pre-trained Models for Speech Recognition and Understanding},
-  author={Yifan Peng and Kwangyoun Kim and Felix Wu and Prashant Sridhar and and Shinji Watanabe},
+  author={Yifan Peng and Kwangyoun Kim and Felix Wu and Prashant Sridhar and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2052,7 +2052,7 @@ year={2024}
   abbr={SSL},
   abbr_publisher={ICASSP},
   title={Fully Unsupervised Topic Clustering of Unlabelled Spoken Audio Using Self-Supervised Representation Learning and Topic Model},
-  author={Takashi Maekaku and Yuya Fujita and Xuankai Chang and and Shinji Watanabe},
+  author={Takashi Maekaku and Yuya Fujita and Xuankai Chang and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2061,7 +2061,7 @@ year={2024}
   abbr={Multimodal},
   abbr_publisher={ICASSP},
   title={The Multimodal Information Based Speech Processing (MISP) 2022 Challenge: Audio-Visual Diarization and Recognition},
-  author={Zhe Wang and Shilong Wu and Hang Chen and Mao-Kui He and Jun Du and Chin-Hui Lee and Jingdong Chen and Shinji Watanabe and Sabato Siniscalchi and Odette Scharenborg and Diyuan Liu and Baocai Yin and Jia Pan and Jianqing Gao and and Cong Liu},
+  author={Zhe Wang and Shilong Wu and Hang Chen and Mao-Kui He and Jun Du and Chin-Hui Lee and Jingdong Chen and Shinji Watanabe and Sabato Siniscalchi and Odette Scharenborg and Diyuan Liu and Baocai Yin and Jia Pan and Jianqing Gao and Cong Liu},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2070,7 +2070,7 @@ year={2024}
   abbr={ASR&SSL},
   abbr_publisher={ICASSP},
   title={FINDADAPTNET: Find and Insert Adapters by Learned Layer Importance},
-  author={Junwei Huang and Karthik Ganesan and Soumi Maiti and Young Min Kim and Xuankai Chang and Paul Liang and and Shinji Watanabe},
+  author={Junwei Huang and Karthik Ganesan and Soumi Maiti and Young Min Kim and Xuankai Chang and Paul Liang and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }
@@ -2079,7 +2079,7 @@ year={2024}
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={I3D: Transformer architectures with input-dependent dynamic depth for speech recognition},
-  author={Yifan Peng and Jaesong Lee and and Shinji Watanabe},
+  author={Yifan Peng and Jaesong Lee and Shinji Watanabe},
   booktitle=ICASSP,
   year={2023}
 }


### PR DESCRIPTION
Follow-up to #284. The automated review there flagged two `author`-field
problems. Both are real and both predate #284 — they only appeared in that
PR's review because they sat in its diff context. Diff here touches only
`author` lines (32 insertions / 32 deletions).

## 1. Missing space after the separator — 2 entries, visibly wrong output

These were the actual bug. `and` glued to the following given name makes
BibTeX read two authors as one, dropping a given name and attaching the
surname to the previous author:

| Location | BibTeX | Rendered as |
|---|---|---|
| `papers.bib:1775` | `Yifan Peng andKwangyoun Kim` | **`Yifan Peng Kim`** |
| `papers.bib:1711` | `Chao Weng andDong Yu` | **`Chao Weng Yu`** |

So the publications page was showing two people who do not exist, and
omitting Kwangyoun Kim and Dong Yu from those entries.

## 2. Duplicated separator — 30 entries, no visible effect

All 30 are 2023 entries in a contiguous block (lines 1821–2082), so this
looks like one bad import of that year's list rather than 30 separate
typos. `and and` parses as an empty author.

Worth correcting as data hygiene, but to be accurate about severity:
bibtex-ruby silently drops the empty entry, so nothing was broken on the
page. `Yifan Peng and Jaesong Lee and and Shinji Watanabe` already rendered
as `Yifan Peng, Jaesong Lee, and Shinji Watanabe`. The automated review
described this as leading to malformed output; that is true of BibTeX in
general but did not happen with this toolchain.

## Verification

`bundle exec jekyll build`, then checked the built
`_site/publications/index.html`:

- `Yifan Peng Kim` — 0 occurrences (was 1)
- `Chao Weng Yu` — 0 occurrences (was 1)
- the affected entries now list every author, e.g. `Jinchuan Tian, Jianwei Yu,
  Hangting Chen, Brian Yan, Chao Weng, Dong Yu, and Shinji Watanabe`
- `Kwangyoun Kim` and `Dong Yu` both present

A remaining scan of all 436 `author` lines finds 0 instances of either
pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)