### PR TITLE
Add 37 publications missing from papers.bib

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -19,6 +19,258 @@
 @string{EACLFindings = {Findings of the Association for Computational Linguistics: EACL}}
 
 
+@article{bando2026online,
+  abbr={SS&SD&ASR},
+  abbr_publisher={TASLP},
+  title={Online Frontend System for Multi-Talker DSR Using Neural Blind Source Separation and Diarization},
+  author={Yoshiaki Bando and Tomohiko Nakamura and Satoru Fukayama and Shinji Watanabe},
+  journal=TASLP,
+  year={2026},
+}
+
+@article{sato2026uncertainty,
+  abbr={ASR},
+  abbr_publisher={OJSP},
+  title={Uncertainty-Based Streaming ASR with Evidential Deep Learning},
+  author={Hiroaki Sato and Asahi Sakuma and Ryuga Sugano and Tadashi Kumano and Yoshihiko Kawai and Shinji Watanabe and Tetsuji Ogawa},
+  journal={IEEE Open Journal of Signal Processing},
+  year={2026},
+}
+
+@article{kim2026modal,
+  abbr={Multimodal},
+  abbr_publisher={TMM},
+  title={TMT: Tri-Modal Translation between Speech, Image, and Text by Processing Different Modalities as Different Languages},
+  author={Minsu Kim and Jee-weon Jung and Hyeongseop Rha and Soumi Maiti and Siddhant Arora and Xuankai Chang and Shinji Watanabe and Yong Man Ro},
+  journal={IEEE Transactions on Multimedia},
+  year={2026},
+}
+
+@article{masuyama2026integration,
+  abbr={SS&ASR},
+  abbr_publisher={CSL},
+  title={An End-to-End Integration of Speech Separation and Recognition with Self-Supervised Learning Representation},
+  author={Yoshiki Masuyama and Xuankai Chang and Wangyou Zhang and Samuele Cornell and Zhong-Qiu Wang and Nobutaka Ono and Yanmin Qian and Shinji Watanabe},
+  journal={Computer Speech & Language},
+  year={2026},
+}
+
+@inproceedings{koudounas2026benchmarking,
+  abbr={Evaluation},
+  abbr_publisher={EMNLP},
+  title={Benchmarking Speech-to-Speech Translation Models},
+  author={Alkis Koudounas and Hayato Futami and Quentin Jodelet and Osamu Take and Shinji Watanabe and Emiru Tsunoo},
+  booktitle={Findings of EMNLP},
+  year={2026},
+}
+
+@inproceedings{kim2026long,
+  abbr={Speech-LLM},
+  abbr_publisher={EMNLP},
+  title={Long Listening Thoughts: Eliciting Open Auditory Reasoning with Deliberative Perception and Cognitive Refinement},
+  author={Jaeyeon Kim and Chao-Han Huck Yang and Luoyi Zhang and Chan-Jan Hsu and Fernando Ruiloba Portilla and Jinchuan Tian and Shinji Watanabe and Carlos Busso},
+  booktitle={Findings of EMNLP},
+  year={2026},
+}
+
+@inproceedings{shih2026bench,
+  abbr={Evaluation},
+  abbr_publisher={EMNLP},
+  title={MP-Bench: Evaluating Voice Agents as a Multiparty Conversation Participant},
+  author={Yi-Jen Shih and Shih-Yun Shan Kuan and Guan-Ting Lin and Kai-Wei Chang and Siddhant Arora and Shu-wen Yang and Abdelrahman Mohamed and Shinji Watanabe and Hung-yi Lee and David Harwath},
+  booktitle={Findings of EMNLP},
+  year={2026},
+}
+
+@inproceedings{hsu2026listen,
+  abbr={ASR&Speech-LLM},
+  abbr_publisher={EMNLP},
+  title={Listen to the Latents: Self-Correcting Speech Recognition in Large Audio Language Models Through Hidden-State Interactions},
+  author={Chan-Jan Hsu and Jaeyeon Kim and Chao-Han Huck Yang and Shinji Watanabe and Hung-yi Lee and Carlos Busso},
+  booktitle={Findings of EMNLP},
+  year={2026},
+}
+
+@inproceedings{tian2026bagpiper,
+  abbr={Speech-LLM},
+  abbr_publisher={COLM},
+  title={Bagpiper: Solving Open-Ended Audio Tasks via Rich Captions},
+  author={Jinchuan Tian and Haoran Wang and Bo-Hao Su and Chien-yu Huang and Qingzheng Wang and Jiatong Shi and William Chen and Xun Gong and Siddhant Arora and Chin-Jou Li and Masao Someki and Takashi Maekaku and Yusuke Shinohara and Jin Sakuma and Keita Goto and Chao-Han Huck Yang and Shinji Watanabe},
+  booktitle={Proceedings of COLM},
+  year={2026},
+}
+
+@inproceedings{chen2026yodas,
+  abbr={ASR},
+  abbr_publisher={Interspeech},
+  title={YODAS v3: Over 1 Million Hours of High-Bandwidth, Stereophonic, Multilingual Speech},
+  author={William Chen and Shinnosuke Takamichi and Sayaka Shiota and Satoru Fukayama and Samuele Cornell and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{polok2026mind,
+  abbr={ASR&SD},
+  abbr_publisher={Interspeech},
+  title={Mind the Gap: Impact of Synthetic Conversational Data on Multi-Talker ASR and Speaker Diarization},
+  author={Alexander Polok and Ivan Medennikov and Jan Černocký and Shinji Watanabe and Lukáš Burget and Samuele Cornell},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{polok2026grounding,
+  abbr={Speech-LLM&SD},
+  abbr_publisher={Interspeech},
+  title={Grounding Spoken LLMs in Multi-Speaker Audio via Diarization Conditioning},
+  author={Alexander Polok and Samuele Cornell and Sathvik Udupa and Jan Černocký and Shinji Watanabe and Lukáš Burget},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{gong2026bagpiper,
+  abbr={Speech-LLM},
+  abbr_publisher={Interspeech},
+  title={Bagpiper-Edit: Zero-Shot Open-Ended Audio Editing via Rich-Caption},
+  author={Xun Gong and Jinchuan Tian and Haoran Wang and William Chen and Shinji Watanabe and Yanmin Qian},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{tian2026bagpipertts,
+  abbr={TTS&Speech-LLM},
+  abbr_publisher={Interspeech},
+  title={Bagpiper-TTS: Natural Language Guided Universal Speech Synthesis},
+  author={Jinchuan Tian and Haoran Wang and Siddhant Arora and Takashi Maekaku and Keita Goto and Jin Sakuma and Yusuke Shinohara and Chao-Han Huck Yang and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{tao2026anchor,
+  abbr={Evaluation},
+  abbr_publisher={Interspeech},
+  title={ANCHOR: Autoregressive Non-intrusive Chunk-Ordered Refinement for Joint Multi-Resolution Speech Quality Modeling},
+  author={Zhuoyan Tao and Jiatong Shi and Hye-jin Shim and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{wang2026efficient,
+  abbr={Speech-LLM},
+  abbr_publisher={Interspeech},
+  title={An Efficient vLLM-Based Inference Pipeline for Unified Audio Understanding and Generation},
+  author={Haoran Wang and Jinchuan Tian and Siddhant Arora and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{bharadwaj2026empirical,
+  abbr={ASR},
+  abbr_publisher={Interspeech},
+  title={An Empirical Recipe for Universal Phone Recognition},
+  author={Shikhar Bharadwaj and Chin-Jou Li and Kwanghee Choi and Eunjung Yeo and William Chen and Shinji Watanabe and David Mortensen},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{kashiwagi2026speaker,
+  abbr={ASR&Speaker},
+  abbr_publisher={Interspeech},
+  title={Speaker-Aware Hypothesis Clustering and Merging for Target-Speaker-free and Target-Speaker Multi-Talker ASR},
+  author={Yosuke Kashiwagi and Osamu Take and Hayato Futami and Emiru Tsunoo and Siddhant Arora and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{wang2026urgent,
+  abbr={SE&Evaluation},
+  abbr_publisher={Interspeech},
+  title={URGENT-MOS: Unified Multi-Metric and Preference Learning for Robust Speech Quality Assessment},
+  author={Wei Wang and Wangyou Zhang and Chenda Li and Jiahe Wang and Marvin Sach and Kohei Saijo and Samuele Cornell and Yihui Fu and Zhaoheng Ni and Mengxiao Bi and Tim Fingscheidt and Shinji Watanabe and Yanmin Qian},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{goto2026online,
+  abbr={SSL},
+  abbr_publisher={Interspeech},
+  title={Online Predictive Coding for Dual-Mode Self-Supervised Speech Models},
+  author={Keita Goto and Takashi Maekaku and Jin Sakuma and Jinchuan Tian and Yusuke Shinohara and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{yano2026adapting,
+  abbr={Speech-LLM},
+  abbr_publisher={Interspeech},
+  title={Adapting Text LLMs to Speech via Multimodal Depth Up-Scaling},
+  author={Kazuki Yano and Jun Suzuki and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{udupa2026endpoint,
+  abbr={Dialogue},
+  abbr_publisher={Interspeech},
+  title={Endpoint Anticipation for Low-Latency Spoken Dialogue},
+  author={Sathvik Udupa and Shinji Watanabe and Petr Schwarz and Jan Černocký},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{someki2026espnet3,
+  abbr={ASR},
+  abbr_publisher={Interspeech},
+  title={ESPnet3: Infrastructure for Scalable Speech and Audio Research in the Foundation Model Era},
+  author={Masao Someki and Alexander Polok and Carlos Carvalho and Chyi-Jiunn Lin and Da-Hee Yang and Jiatong Shi and Jinchuan Tian and Nelson Enrique Yalta Soplin and Samuele Cornell and Siddhant Arora and Francisco Teixeira and Wei Wang and William Chen and Alberto Abad and Chenda Li and Shinji Watanabe and Wangyou Zhang},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{tawara2026spoke,
+  abbr={Evaluation},
+  abbr_publisher={Interspeech},
+  title={Who Spoke What When? Evaluating Spoken Language Models for Conversational ASR with Semantic and Overlap-Aware Metrics},
+  author={Naohiro Tawara and Samuele Cornell and Alexander Polok and Marc Delcroix and Lukáš Burget and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{fukuda2026evaluating,
+  abbr={Evaluation},
+  abbr_publisher={Interspeech},
+  title={Evaluating Large Language Models Abilities for Addressee, Turn-change, and Next Speaker Prediction in Meetings},
+  author={Ryo Fukuda and Takatomo Kano and Siddhant Arora and Marc Delcroix and Naohiro Tawara and Atsunori Ogawa and Yuya Chiba and Atsushi Ando and William Chen and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{naini2026comparative,
+  abbr={ER&Speech-LLM},
+  abbr_publisher={Interspeech},
+  title={Comparative Reasoning: Making an Audio Language Model Better at Comparing Emotions},
+  author={Abinay Reddy Naini and Jaeyeon Kim and Chao-Han Huck Yang and Shinji Watanabe and Carlos Busso},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{takizawa2026dissecting,
+  abbr={SSL&Tokenizer},
+  abbr_publisher={Interspeech},
+  title={Dissecting Sensitivity to Training Language in Self-Supervised Speech Learning Using Neural Audio Codec Tokens},
+  author={Daigo Takizawa and Tomohiko Nakamura and Samuele Cornell and William Chen and Satoru Fukayama and Shinji Watanabe},
+  booktitle=interspeech,
+  year={2026},
+}
+
+@inproceedings{aldeneh2026which,
+  abbr={ASR},
+  abbr_publisher={Interspeech},
+  title={Which Data Matter? Embedding-Based Data Selection for Speech Recognition},
+  author={Zakaria Aldeneh and Skyler Seto and Maureen de Seyssel and Jie Chi and Zijin Gu and Takuya Higuchi and Jee-weon Jung and Shinji Watanabe and David Grangier and Barry-John Theobald and Tatiana Likhomanenko},
+  booktitle=interspeech,
+  year={2026},
+}
+
 @inproceedings{sun2026adept,
   abbr={Speech-LLM},
   abbr_publisher={ICML},
@@ -215,6 +467,42 @@
   author={Haoran Wang and Jiatong Shi and Jinchuan Tian and Bohan Li and Kai Yu and Shinji Watanabe},
   booktitle={EACLFindings},
   year={2026}
+}
+
+@article{liu2025aligning,
+  abbr={ASR},
+  abbr_publisher={TASLP},
+  title={Aligning Speech to Languages to Enhance Code-switching Speech Recognition},
+  author={Hexin Liu and Xiangyu Zhang and Haoyang Zhang and Leibny Paola Garcia-Perera and Andy W. H. Khong and Eng Siong Chng and Shinji Watanabe},
+  journal=TASLP,
+  year={2025},
+}
+
+@article{jung2025spoofceleb,
+  abbr={Speaker},
+  abbr_publisher={OJSP},
+  title={SpoofCeleb: Speech Deepfake Detection and SASV in the Wild},
+  author={Jee-weon Jung and Yihan Wu and Xin Wang and Ji-Hoon Kim and Soumi Maiti and Yuta Matsunaga and Hye-jin Shim and Jinchuan Tian and Nicholas Evans and Joon Son Chung and Wangyou Zhang and Seyun Um and Shinnosuke Takamichi and Shinji Watanabe},
+  journal={IEEE Open Journal of Signal Processing},
+  year={2025},
+}
+
+@article{sudo2025joint,
+  abbr={ASR},
+  abbr_publisher={TASLP},
+  title={Joint Beam Search Integrating CTC, Attention, and Transducer Decoders},
+  author={Yui Sudo and Muhammad Shakeel and Yosuke Fukumoto and Brian Yan and Jiatong Shi and Yifan Peng and Shinji Watanabe},
+  journal=TASLP,
+  year={2025},
+}
+
+@article{guo2025whisper,
+  abbr={ASR&Speaker},
+  abbr_publisher={TASLP},
+  title={SQ-Whisper: Speaker-Querying based Whisper Model for Target-Speaker ASR},
+  author={Pengcheng Guo and Xuankai Chang and Hang Lv and Shinji Watanabe and Lei Xie},
+  journal=TASLP,
+  year={2025},
 }
 
 @inproceedings{shi2025arecho,
@@ -761,6 +1049,15 @@
   year={2025},
 }
 
+
+@inproceedings{kwak2024voxmm,
+  abbr={Dataset&ASR&SD},
+  abbr_publisher={ICASSP},
+  title={VoxMM: Rich Transcription of Conversations in the Wild},
+  author={Doyeop Kwak and Jaemin Jung and Kihyun Nam and Youngjoon Jang and Jee-weon Jung and Shinji Watanabe and Joon Son Chung},
+  booktitle=ICASSP,
+  year={2024},
+}
 
 @inproceedings{chen_emnlp2024,
   abbr={SSL},
@@ -1395,6 +1692,42 @@ booktitle=ICASSP,
 year={2024}
 }
 
+
+@article{lu2023improving,
+  abbr={SE},
+  abbr_publisher={TASLP},
+  title={Improving Speech Enhancement Performance by Leveraging Contextual Broad Phonetic Class Information},
+  author={Yen-Ju Lu and Chia-Yu Chang and Cheng Yu and Ching-Feng Liu and Jeih-weih Hung and Shinji Watanabe and Yu Tsao},
+  journal=TASLP,
+  year={2023},
+}
+
+@inproceedings{polk2023incremental,
+  abbr={ST},
+  abbr_publisher={Interspeech},
+  title={Incremental Blockwise Beam Search for Simultaneous Speech Translation with Controllable Quality-Latency},
+  author={Peter Polák and Brian Yan and Shinji Watanabe and Alex Waibel and Ondřej Bojar},
+  booktitle=interspeech,
+  year={2023},
+}
+
+@inproceedings{shon2023slue,
+  abbr={SLU&Evaluation},
+  abbr_publisher={ACL},
+  title={SLUE Phase-2: A Benchmark Suite of Diverse Spoken Language Understanding Tasks},
+  author={Suwon Shon and Siddhant Arora and Chyi-Jiunn Lin and Ankita Pasad and Felix Wu and Roshan S Sharma and Wei-Lun Wu and Hung-yi Lee and Karen Livescu and Shinji Watanabe},
+  booktitle=ACL,
+  year={2023},
+}
+
+@inproceedings{tian2023bayes,
+  abbr={ASR},
+  abbr_publisher={ICLR},
+  title={Bayes Risk {CTC}: Controllable {CTC} Alignment in Sequence-to-Sequence Tasks},
+  author={Jinchuan Tian and Brian Yan and Jianwei Yu and Chao Weng and Dong Yu and Shinji Watanabe},
+  booktitle=ICLR,
+  year={2023},
+}
 
 @inproceedings{chou2023evaluating,
     abbr={ASR},


### PR DESCRIPTION
Papers that appear on [Shinji's publication list](https://sites.google.com/view/shinjiwatanabe/publications)
but were absent from `_bibliography/papers.bib`. Found by diffing the two lists;
`abbr`, `year` and the citation keys were then filled in and checked by hand.

**333 insertions, 0 deletions.** Entries go at the head of their year block, so
the file stays reverse-chronological.

| Year | Count |
|---|---|
| 2026 | 28 |
| 2025 | 4 |
| 2024 | 1 |
| 2023 | 4 |

## Years

Most come from the venue abbreviation on the source page (`Proc. Interspeech'26`).
Five journal papers are listed there only as "accepted" with no year, so the year
is Crossref's `published-print`. **That differs from the year in the DOI, and the
DOI is the misleading one:**

| Paper | DOI says | Actually published |
|---|---|---|
| SQ-Whisper | `taslp.2024.3513835` | TASLP **vol. 33 (2025)**, pp. 175–185 |
| Masuyama et al., SS + ASR integration | `csl.2025.101813` | CSL **vol. 95 (2026-01)** |

The other three (Online Frontend, Uncertainty-Based Streaming ASR, Aligning
Speech to Languages) were re-checked the same way and their DOI years happened to
be right.

## Topic labels

`abbr` values reuse the existing vocabulary, and each follows the closest
precedent already in this file rather than being invented:

| Paper | abbr | Precedent |
|---|---|---|
| YODAS v3 | `ASR` | YODAS v1 is `ASR`, not `Dataset` |
| ESPnet3 | `ASR` | the original ESPnet toolkit paper, and every OWSM paper — which is what its experiments use |
| Bayes Risk CTC | `ASR` | Bayes Risk Transducer |
| ANCHOR | `Evaluation` | ARECHO, which it explicitly extends |
| URGENT-MOS | `SE&Evaluation` | the URGENT series |
| MP-Bench, Who Spoke What When, Evaluating LLMs…, Benchmarking S2ST | `Evaluation` | LALM-as-a-Judge, Full-Duplex-Bench, PRiSM all use `Evaluation` alone |
| VoxMM | `Dataset&ASR&SD` | its abstract makes the corpus the contribution, and it ships both ASR and diarisation annotations |

## Title fixes

Two titles arrived ALL-CAPS from camera-ready PDFs and were restored to match how
the rest of the file is written:

- `VOXMM: RICH TRANSCRIPTION OF CONVERSATIONS IN THE WILD` → `VoxMM: Rich Transcription of Conversations in the Wild`
- `BAYES RISK CTC: CONTROLLABLE CTC ALIGNMENT...` → `Bayes Risk {CTC}: Controllable {CTC} Alignment in Sequence-to-Sequence Tasks`

## Verification

`bundle exec jekyll build` (needs `LANG`/`LC_ALL` set to a UTF-8 locale — a
pre-existing quirk):

- 473 entries in the file, **473 rendered** — nothing silently dropped
- all 37 new entries present, with correct topic and venue badges
- no new duplicate citation keys

Two pre-existing issues were checked and are **unchanged** by this PR: one
ordering violation at the 2018/2022 boundary, and six duplicate citation keys
(`chang2020end`, `li2021dual`, `lu2022icassp`, `muqiao_interspeech2022`,
`seki19inter`, `yifan_icassp2023`). The duplicates do not cost any entries on the
page — the rendered count matches the file — but they are worth cleaning up
separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)