### PR TITLE
Make venue strings consistent in papers.bib

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -51,7 +51,7 @@
   abbr_publisher={CSL},
   title={An End-to-End Integration of Speech Separation and Recognition with Self-Supervised Learning Representation},
   author={Yoshiki Masuyama and Xuankai Chang and Wangyou Zhang and Samuele Cornell and Zhong-Qiu Wang and Nobutaka Ono and Yanmin Qian and Shinji Watanabe},
-  journal={Computer Speech & Language},
+  journal={Computer Speech \& Language},
   year={2026},
 }
 
@@ -60,7 +60,7 @@
   abbr_publisher={EMNLP},
   title={Benchmarking Speech-to-Speech Translation Models},
   author={Alkis Koudounas and Hayato Futami and Quentin Jodelet and Osamu Take and Shinji Watanabe and Emiru Tsunoo},
-  booktitle={Findings of EMNLP},
+  booktitle={Proceedings of Findings of EMNLP},
   year={2026},
 }
 
@@ -69,7 +69,7 @@
   abbr_publisher={EMNLP},
   title={Long Listening Thoughts: Eliciting Open Auditory Reasoning with Deliberative Perception and Cognitive Refinement},
   author={Jaeyeon Kim and Chao-Han Huck Yang and Luoyi Zhang and Chan-Jan Hsu and Fernando Ruiloba Portilla and Jinchuan Tian and Shinji Watanabe and Carlos Busso},
-  booktitle={Findings of EMNLP},
+  booktitle={Proceedings of Findings of EMNLP},
   year={2026},
 }
 
@@ -78,7 +78,7 @@
   abbr_publisher={EMNLP},
   title={MP-Bench: Evaluating Voice Agents as a Multiparty Conversation Participant},
   author={Yi-Jen Shih and Shih-Yun Shan Kuan and Guan-Ting Lin and Kai-Wei Chang and Siddhant Arora and Shu-wen Yang and Abdelrahman Mohamed and Shinji Watanabe and Hung-yi Lee and David Harwath},
-  booktitle={Findings of EMNLP},
+  booktitle={Proceedings of Findings of EMNLP},
   year={2026},
 }
 
@@ -87,7 +87,7 @@
   abbr_publisher={EMNLP},
   title={Listen to the Latents: Self-Correcting Speech Recognition in Large Audio Language Models Through Hidden-State Interactions},
   author={Chan-Jan Hsu and Jaeyeon Kim and Chao-Han Huck Yang and Shinji Watanabe and Hung-yi Lee and Carlos Busso},
-  booktitle={Findings of EMNLP},
+  booktitle={Proceedings of Findings of EMNLP},
   year={2026},
 }
 
@@ -2459,7 +2459,7 @@ year={2024}
   abbr_publisher={CSL},
   title={A Dilemma of Ground Truth in Noisy Speech Separation and an Approach to Lessen the Impact of Imperfect Training Data},
   author={Matthew Maciejewski and Jing Shi and Shinji Watanabe and Sanjeev Khudanpur},
-  booktitle={Computer Speech & Language},
+  booktitle={Computer Speech \& Language},
   year={2022},
 }
 
@@ -3054,7 +3054,7 @@ year={2024}
   abbr={SE&ASR},
   abbr_publisher={CSL},
   title = {An investigation of neural uncertainty estimation for target speaker extraction equipped RNN transducer},
-  journal = {Computer Speech & Language},
+  journal = {Computer Speech \& Language},
   volume = {73},
   pages = {101327},
   year = {2022},


### PR DESCRIPTION
Follow-up to the automated review on #286. Both of its points were correct.
Each was checked against the rendered page before anything was changed, and
they turned out to differ a lot in severity.

**7 insertions, 7 deletions.** No entries added or removed.

## 1. `Findings of EMNLP` — a real, visible inconsistency

The four entries added in #286 used a venue string the file did not already use,
so the publications page was showing **two different names for one venue**:

| Rendered on the page | Count |
|---|---|
| `Findings of EMNLP` | 4 (added in #286) |
| `Proceedings of Findings of EMNLP` | 2 (2022 entries) |

The `Proceedings of ...` form matches both the existing entries and the `@string`
macros at the top of the file (`ACLFindings`, `EACLFindings`), so the new entries
move to it. All six now read the same.

## 2. Ampersand escaping — a convention issue, not a rendering one

`\&` was already the majority form here (4 of 6) and is the correct BibTeX
spelling, so escaping the rest is right. But to be accurate about the impact:
**jekyll-scholar renders `\&` and `&` identically.** All seven
`Computer Speech & Language` occurrences on the page were already the same before
this change, and still are. Nothing was broken; the review's "to avoid TeX
parsing issues" is true of BibTeX generally but did not apply here.

Two of the three unescaped entries predate #286 (`papers.bib:2462`, `:3057`).
They are included because leaving them would defeat the point — the file would
still carry two spellings.

## Note on the review's line numbers

As on #284, the cited lines were consistently **off by one** (55/64/70/79/88 vs
the actual 54/63/72/81/90) — they look like diff positions read as file lines.
The substance was right both times; only the coordinates need translating.

## Verification

`bundle exec jekyll build`:

- 473 entries rendered — unchanged
- `Proceedings of Findings of EMNLP` × 6, `Findings of EMNLP` × 0
- `Computer Speech & Language` × 7, all identical
- no stray backslashes in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)