### PR TITLE
Derive the publications year range instead of hard-coding it

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2504,7 +2504,7 @@ year={2024}
   abbr_publisher={IWSLT},
   title={Findings of the IWSLT 2022 Evaluation Campaign},
   author={Antonios Anastasopoulos and Loïc Barrault and Luisa Bentivogli and Marcely Zanon Boito and Ondřej Bojar and Roldano Cattoni and Anna Currey and Georgiana Dinu and Kevin Duh and Maha Elbayad and Clara Emmanuel and Yannick Estève and Marcello Federico and Christian Federmann and Souhir Gahbiche and Hongyu Gong and Roman Grundkiewicz and Barry Haddow and Benjamin Hsu and Dávid Javorský and Vĕra Kloudová and Surafel Lakew and Xutai Ma and Prashant Mathur and Paul McNamee and Kenton Murray and Maria Nǎdejde and Satoshi Nakamura and Matteo Negri and Jan Niehues and Xing Niu and John Ortega and Juan Pino and Elizabeth Salesky and Jiatong Shi and Matthias Sperber and Sebastian Stüker and Katsuhito Sudoh and Marco Turchi and Yogesh Virkar and Alexander Waibel and Changhan Wang and Shinji Watanabe},
-  booktitle=IWSLTT,
+  booktitle=IWSLT,
   year={2022},
 }
 

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,7 +2,6 @@
 layout: page
 permalink: /publications/
 title: Publications
-years: [2026, 2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017]
 nav: true
 order: 2
 ---
@@ -20,9 +19,23 @@ order: 2
 
 <div class="publications">
 
-{% for y in page.years %}
+{%- comment -%}
+  The year range is derived rather than hand-listed. A hard-coded list silently
+  drops any paper whose year is not on it: a 2027 entry rendered nowhere while
+  `jekyll build` still exited 0 and printed no warning. "+1" leaves headroom for
+  next year's already-accepted papers.
+
+  A year with no papers emits `<ol class="bibliography"></ol>` rather than an
+  empty string, so the guard looks for an actual list item instead of testing
+  for emptiness. Without it, 2017 printed a bare heading with nothing under it.
+{%- endcomment -%}
+{% assign maxyear = site.time | date: "%Y" | plus: 1 %}
+{% for y in (2017..maxyear) reversed %}
+  {% capture bibyear %}{% bibliography -f papers -q @*[year={{y}}]* %}{% endcapture %}
+  {% if bibyear contains "<li" %}
   <h2>{{ y }}</h2>
-  {% bibliography -f papers -q @*[year={{y}}]* %}
+  {{ bibyear }}
+  {% endif %}
 {% endfor %}
 
 </div>


### PR DESCRIPTION
Two fixes, both for defects that were live on www.wavlab.org and neither of which
`jekyll build` complained about.

## 1. Hard-coded year list silently dropped papers

`_pages/publications.md` carried `years: [2026, 2025, …, 2017]` in its front
matter and queried the bibliography once per listed year. **A paper whose year is
not on that list is never queried, so it renders nowhere** — and the build exits
0 with no warning.

Measured before changing anything: a probe entry with `year={2027}` added to
`papers.bib` produced **0 occurrences** in the built page. The list ended at 2026,
so this would have started dropping papers in January.

The range is now derived from `site.time` with one year of headroom, which matches
how this bibliography behaves — 2026 papers were already in the file in September
2026.

```liquid
{% assign maxyear = site.time | date: "%Y" | plus: 1 %}
{% for y in (2017..maxyear) reversed %}
  {% capture bibyear %}{% bibliography -f papers -q @*[year={{y}}]* %}{% endcapture %}
  {% if bibyear contains "<li" %}
  <h2>{{ y }}</h2>
  {{ bibyear }}
  {% endif %}
{% endfor %}
```

The `contains "<li"` guard is load-bearing and non-obvious: a year with no papers
emits `<ol class="bibliography"></ol>`, **not** an empty string. Testing for
emptiness looks right and does nothing — my first attempt did exactly that and
still printed a bare heading. This also removes an existing empty `<h2>2017</h2>`
that was on the live page, because 2017 was on the list but no 2017 papers are in
the file.

## 2. `IWSLTT` — a one-character typo rendering as garbage

`papers.bib:2507` read `booktitle=IWSLTT`. That is not one of the 18 defined
`@string` macros (`IWSLT` is). BibTeX does not error on an undefined macro — it
emits the name lowercased — so the entry rendered:

| | |
|---|---|
| before | `In iwsltt 2022` |
| after | `In Proceedings of the 18th International Conference on Spoken Language Translation (IWSLT) 2022` |

## Verification

`bundle exec jekyll build`:

- 473 entries rendered — unchanged
- year headings 2026 → 2018, **no empty sections**
- a `year={2027}` probe renders (it did not before)
- the IWSLT entry now shows its real venue

🤖 Generated with [Claude Code](https://claude.com/claude-code)