### PR TITLE
Give the six duplicated citation keys unique names

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -2408,7 +2408,7 @@ year={2024}
   year={2023}
 }
 
-@inproceedings{yifan_icassp2023,
+@inproceedings{peng2023i3d,
   abbr={ASR},
   abbr_publisher={ICASSP},
   title={I3D: Transformer architectures with input-dependent dynamic depth for speech recognition},
@@ -2760,7 +2760,7 @@ year={2024}
   year={2022},
 }
 
-@inproceedings{muqiao_interspeech2022,
+@inproceedings{yang2022finegrained,
   abbr={SE},
   abbr_publisher={Interspeech},
   title={Improving Speech Enhancement through Fine-Grained Speech Characteristics},
@@ -2874,7 +2874,7 @@ year={2024}
   year={2022}
 }
 
-@inproceedings{lu2022icassp,
+@inproceedings{chen2022misp,
   abbr={Multimodal},
   abbr_publisher={ICASSP},
   title={THE FIRST MULTIMODAL INFORMATION BASED SPEECH PROCESSING (MISP) CHALLENGE: DATA, TASKS, BASELINES AND RESULTS},
@@ -3509,7 +3509,7 @@ year={2024}
   organization={IEEE}
 }
 
-@inproceedings{li2021dual,
+@inproceedings{li2021dualpath,
   abbr={SE},
   abbr_publisher={ICASSP},
   title={Dual-Path Modeling for Long Recording Speech Separation in Meetings},
@@ -3829,7 +3829,7 @@ year={2024}
   year={2020},
   code={https://demotoshow.github.io/}
 }
-@inproceedings{chang2020end,
+@inproceedings{chang2020adaptive,
   abbr={ASR},
   abbr_publisher={Interspeech},
   title={End-to-End ASR with Adaptive Span Self-Attention.},
@@ -4096,7 +4096,7 @@ year={2024}
   year={2019}
 }
 
-@inproceedings{seki19inter,
+@inproceedings{seki2019vectorized,
   abbr={ASR},
   abbr_publisher={Interspeech},
   title={Vectorized Beam Search for CTC-Attention-based Speech Recognition},


### PR DESCRIPTION
Six citation keys in `papers.bib` were each shared by two different papers.

**This was not harmless.** jekyll-scholar does not error on a duplicate key — it
silently mangles the second entry's key by **incrementing its last character**,
and that key becomes the entry's HTML `id` on the publications page
([bib.html:22](../blob/source/_layouts/bib.html#L22)):

| In papers.bib | Rendered ids |
|---|---|
| `chang2020end` ×2 | `chang2020end`, **`chang2020ene`** (d→e) |
| `li2021dual` ×2 | `li2021dual`, **`li2021duam`** (l→m) |
| `seki19inter` ×2 | `seki19inter`, **`seki19intes`** (r→s) |

So six papers had anchor ids that are meaningless *and* unstable — they shift if
entry order changes. It also broke tooling: a merge script of mine keyed on
citation key and silently collapsed two different papers into one (caught by an
assertion, before it wrote anything).

## The renames

Each pair keeps its first entry's key; the second gets a name in the file's
current convention, `<lastname><year><word>`:

| Old | New | Paper |
|---|---|---|
| `chang2020end` | `chang2020adaptive` | End-to-End ASR with Adaptive Span Self-Attention (Chang, Interspeech 2020) |
| `li2021dual` | `li2021dualpath` | Dual-Path Modeling for Long Recording Speech Separation in Meetings (Li, ICASSP 2021) |
| `lu2022icassp` | `chen2022misp` | The First MISP Challenge (**Hang Chen**, ICASSP 2022) |
| `muqiao_interspeech2022` | `yang2022finegrained` | Improving Speech Enhancement through Fine-Grained Speech Characteristics (Yang, Interspeech 2022) |
| `seki19inter` | `seki2019vectorized` | Vectorized Beam Search for CTC-Attention-based ASR (Seki, Interspeech 2019) |
| `yifan_icassp2023` | `peng2023i3d` | I3D: Transformer architectures with input-dependent dynamic depth (Peng, ICASSP 2023) |

`lu2022icassp` was doubly wrong — that entry's first author is Hang Chen, so the
key named the wrong person as well as colliding.

No other file referenced any of these keys.

## Verification

`bundle exec jekyll build`:

- 473 entries rendered — unchanged
- **473 unique HTML ids, zero duplicates**
- the six mangled ids (`chang2020ene` etc.) are gone
- the six new keys are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)