### PR TITLE
Remove the empty year heading from the per-year paper pages

### DIFF
--- a/_posts/2018-12-31-paper-list.md
+++ b/_posts/2018-12-31-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2018]* %}
 
 </div>

--- a/_posts/2019-12-31-paper-list.md
+++ b/_posts/2019-12-31-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2019]* %}
 
 </div>

--- a/_posts/2020-12-31-paper-list.md
+++ b/_posts/2020-12-31-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2020]* %}
 
 </div>

--- a/_posts/2021-12-31-paper-list.md
+++ b/_posts/2021-12-31-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2021]* %}
 
 </div>

--- a/_posts/2022-12-31-paper-list.md
+++ b/_posts/2022-12-31-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2022]* %}
 
 </div>

--- a/_posts/2023-03-14-paper-list.md
+++ b/_posts/2023-03-14-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2023]* %}
 
 </div>

--- a/_posts/2024-01-30-paper-list.md
+++ b/_posts/2024-01-30-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2024]* %}
 
 </div>

--- a/_posts/2025-01-30-paper-list.md
+++ b/_posts/2025-01-30-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2025]* %}
 
 </div>

--- a/_posts/2026-01-30-paper-list.md
+++ b/_posts/2026-01-30-paper-list.md
@@ -7,9 +7,6 @@ comments: false
 ---
 
 <div class="publications">
-
-
-  <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year=2026]* %}
 
 </div>


### PR DESCRIPTION
Each per-year post contained this line:

```liquid
<h2 class="year">{{y}}</h2>
```

`y` is the loop counter on the publications page. A post has no such variable, so
Liquid rendered an **empty heading**: `<h2 class="year"></h2>`.

An empty heading is not invisible here. `_sass/_base.scss` gives `h2.year` a
`border-top` and a `margin-bottom` of `-2rem`:

- the border drew a line across the page
- the negative margin pulled the paper list up over that line
- the first paper's title appeared with a line through it

All **nine** year pages had this problem, from 2018 to 2026.

## The fix

Remove the heading. Each post title already states the year, for example
"2026 Papers", so the heading was also redundant.

## Verification

`bundle exec jekyll build`:

| Page | Papers | Empty `h2.year` |
|---|---|---|
| 2026 | 50 | none |
| 2025 | 64 | none |
| 2024 | 71 | none |
| 2023 | 77 | none |
| 2022 | 70 | none |
| 2021 | 60 | none |
| 2020 | 23 | none |
| 2019 | 39 | none |
| 2018 | 19 | none |

Paper counts are unchanged. A screenshot of the 2026 page shows the line is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)