### PR TITLE
Fix two errors in the @string macros

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -7,9 +7,9 @@
 @string{EACL = {Proceedings of the Conference of the European Chapter of the Association for Computational Linguistics}}
 @string{NAACL = {Proceedings of the Conference of the North American Chapter of the Association for Computational Linguistics: Human Language Technologies}}
 @string{TASLP = {IEEE/ACM Transactions on Audio, Speech, and Language Processing}}
-@string{IWSLT = {Proceedings of the 18th International Conference on Spoken Language Translation (IWSLT)}}
+@string{IWSLT = {Proceedings of the International Conference on Spoken Language Translation (IWSLT)}}
 @string{VCC = {Voice Conversion Challenge}}
-@string{ASRU = {IEEE Automatic Speech Recogiton and Understanding Workshop (ASRU)}}
+@string{ASRU = {IEEE Automatic Speech Recognition and Understanding Workshop (ASRU)}}
 @string{WASPAA = {IEEE Workshop on Applications of Signal Processing to Audio and Acoustics (WASPAA)}}
 @string{APSIPA = {Asia Pacific Signal and Information Processing Association Annual Summit and Conference (APSIPA ASC)}}
 @string{ICML = {Proceedings of the International Conference on Machine Learning (ICML)}}


### PR DESCRIPTION
Both errors are in macro **bodies**, so each one repeats on every paper that uses
the macro. Two lines changed.

## 1. `ASRU` spelled "Recogiton"

```
- @string{ASRU = {IEEE Automatic Speech Recogiton and Understanding Workshop (ASRU)}}
+ @string{ASRU = {IEEE Automatic Speech Recognition and Understanding Workshop (ASRU)}}
```

The misspelling showed **45 times** on the publications page.

## 2. `IWSLT` contained the edition number "18th"

```
- @string{IWSLT = {Proceedings of the 18th International Conference on Spoken Language Translation (IWSLT)}}
+ @string{IWSLT = {Proceedings of the International Conference on Spoken Language Translation (IWSLT)}}
```

A macro cannot hold an edition number, because every year shares the same macro.
Two papers use `booktitle=IWSLT`: one from 2021 and one from 2022. IWSLT 2021 was
the 18th conference, so the 2022 paper stated the wrong edition.

## Verification

`bundle exec jekyll build`:

| Text on the page | Before | After |
|---|---|---|
| `Recogiton` | 45 | 0 |
| `Speech Recognition and Understanding Workshop` | 0 | 45 |
| `18th International Conference on Spoken` | 2 | 0 |

473 entries rendered, unchanged.

## How these were found

An adversarial design review of the publication tooling read `papers.bib` and
reported both. I verified each against the built page before making a change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)