### PR TITLE
Add the Fall 2026 course: Speech Generation (11-752)

### DIFF
--- a/_pages/courses.md
+++ b/_pages/courses.md
@@ -7,6 +7,10 @@ nav: true
 order: 6
 ---
 
+### 2026 Fall
+
+* [Speech Generation (11-752)]({% post_url 2026-08-31-11752-2026f %})
+
 ### 2026 Spring
 
 * [Speech Technology for Conversational AI (11-692)]({% post_url 2026-01-12-11692-2026s %})

--- a/_posts/2026-08-31-11752-2026f.md
+++ b/_posts/2026-08-31-11752-2026f.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: Speech Generation (11-752) — Fall 2026
+description: Course page for Fall 2026
+date: 2026-08-31 09:00:00-0800
+comments: false
+---
+
+### Course Information
+
+- Instructors: Carlos Busso and Shinji Watanabe
+- Time: Monday and Wednesday, 09:30 AM to 10:50 AM
+- Location: PH 125C
+
+### Course Updates and Materials
+
+- Course Materials & Discussion: Piazza. We will add the link here.
+
+<!-- You can add more details later (TAs, grading, syllabus) -->

--- a/_posts/2026-08-31-11752-2026f.md
+++ b/_posts/2026-08-31-11752-2026f.md
@@ -14,6 +14,6 @@ comments: false
 
 ### Course Updates and Materials
 
-- Course Materials & Discussion: Piazza. We will add the link here.
+- Course Materials & Discussion: Piazza (login required; link will be added soon).
 
 <!-- You can add more details later (TAs, grading, syllabus) -->


### PR DESCRIPTION
This change adds a section for Fall 2026 at the top of the courses page. It also
adds the course page that the section links to.

## Course details

| Field | Value |
|---|---|
| Number | 11-752 |
| Name | Speech Generation |
| Instructors | Carlos Busso and Shinji Watanabe |
| Time | Monday and Wednesday, 09:30 AM to 10:50 AM |
| Location | PH 125C |

## Two decisions

**The course has no Piazza link yet.** The other five course pages all give one.
This page keeps the same line and says that we will add the link. A placeholder
link would not work, so the page states the plan instead.

**The date in the file name gives the URL.** The post uses `2026-08-31`, the
Monday of the first week. The URL becomes `/activities/2026/11752-2026f/`, which
follows the pattern of the other course pages.

This page also gives the instructors, the time and the location. The other
course pages leave those fields out. Their comment says to add them later.

## Test

`bundle exec jekyll build` reports no error.

- The courses page shows "2026 Fall" first, above "2026 Spring".
- The link opens `/activities/2026/11752-2026f/`.
- That page shows the instructors, the time and the location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)